### PR TITLE
Removing keys is unnecessary

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,3 +1,3 @@
 # Placeholder CODEOWNERS file as this repo did not have one
 # Please make a PR adding the correct owner or request that this repo be archived
-* @circleci/security-operations
+* @circleci/default-security-operations

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,3 @@
+# Placeholder CODEOWNERS file as this repo did not have one
+# Please make a PR adding the correct owner or request that this repo be archived
+* @circleci/security-operations

--- a/circle.yml
+++ b/circle.yml
@@ -16,4 +16,3 @@ deployment:
     commands:
       - ./scripts/add-key.sh
       - ./scripts/testflight.sh
-      - ./scripts/remove-key.sh

--- a/scripts/remove-key.sh
+++ b/scripts/remove-key.sh
@@ -1,4 +1,0 @@
-#!/bin/sh
-
-security delete-keychain ios-build.keychain
-rm -f ~/Library/MobileDevice/Provisioning\ Profiles/*


### PR DESCRIPTION
There is no need to remove keys after deployment since the CircleCI
container is destroyed after the build.
